### PR TITLE
[#40] 메뉴그룹 캐싱 제거

### DIFF
--- a/src/main/java/com/restaurant/eatenjoy/controller/MenuGroupController.java
+++ b/src/main/java/com/restaurant/eatenjoy/controller/MenuGroupController.java
@@ -4,8 +4,6 @@ import java.util.List;
 
 import javax.validation.Valid;
 
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,7 +19,6 @@ import com.restaurant.eatenjoy.annotation.Authority;
 import com.restaurant.eatenjoy.dto.MenuGroupDto;
 import com.restaurant.eatenjoy.dto.UpdateMenuGroupDto;
 import com.restaurant.eatenjoy.service.MenuGroupService;
-import com.restaurant.eatenjoy.util.cache.CacheNames;
 import com.restaurant.eatenjoy.util.security.Role;
 
 import lombok.RequiredArgsConstructor;
@@ -35,27 +32,23 @@ public class MenuGroupController {
 	private final MenuGroupService menuGroupService;
 
 	@GetMapping
-	@Cacheable(value = CacheNames.MENU_GROUP, key = "#restaurantId")
 	public List<MenuGroupDto> menuGroups(@PathVariable Long restaurantId) {
 		return menuGroupService.findAllByRestaurantId(restaurantId);
 	}
 
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
-	@CacheEvict(value = CacheNames.MENU_GROUP, key = "#restaurantId")
 	public void register(@PathVariable Long restaurantId, @RequestBody @Valid MenuGroupDto menuGroupDto) {
 		menuGroupService.register(restaurantId, menuGroupDto);
 	}
 
 	@PutMapping
-	@CacheEvict(value = CacheNames.MENU_GROUP, key = "#restaurantId")
-	public void update(@PathVariable Long restaurantId, @RequestBody @Valid UpdateMenuGroupDto menuGroupDto) {
+	public void update(@RequestBody @Valid UpdateMenuGroupDto menuGroupDto) {
 		menuGroupService.update(menuGroupDto);
 	}
 
 	@DeleteMapping("/{menuGroupId}")
-	@CacheEvict(value = CacheNames.MENU_GROUP, key = "#restaurantId")
-	public void delete(@PathVariable Long restaurantId, @PathVariable Long menuGroupId) {
+	public void delete(@PathVariable Long menuGroupId) {
 		menuGroupService.delete(menuGroupId);
 	}
 

--- a/src/main/java/com/restaurant/eatenjoy/util/cache/CacheNames.java
+++ b/src/main/java/com/restaurant/eatenjoy/util/cache/CacheNames.java
@@ -11,12 +11,9 @@ public class CacheNames {
 
 	public static final String RESTAURANT = "restaurant";
 
-	public static final String MENU_GROUP = "menuGroup";
-
 	@Getter
 	public enum TimeToLive {
-		RESTAURANT(CacheNames.RESTAURANT, Duration.ofHours(1)),
-		MENU_GROUP(CacheNames.MENU_GROUP, Duration.ofHours(1));
+		RESTAURANT(CacheNames.RESTAURANT, Duration.ofHours(1));
 
 		private final String name;
 		private final Duration ttl;


### PR DESCRIPTION
메뉴 그룹 조회 같은 경우에는 레스토랑 오너가 최초 레스토랑 등록 후 신규 메뉴그룹을 추가하거나, 
메뉴를 등록할 때 조회하기 때문에 사용량이 극히 적을꺼라 판단하여 캐싱을 제거해습니다.