### PR TITLE
[#70] 메뉴 수정 시 신규 이미지 파일 데이터 삭제 이슈

### DIFF
--- a/src/main/java/com/restaurant/eatenjoy/service/MenuService.java
+++ b/src/main/java/com/restaurant/eatenjoy/service/MenuService.java
@@ -40,12 +40,12 @@ public class MenuService {
 	public void update(Long restaurantId, UpdateMenuDto updateMenuDto) {
 		validateMenuName(restaurantId, updateMenuDto.getId(), updateMenuDto.getName(), updateMenuDto.getUploadFile());
 
-		menuDao.updateById(updateMenuDto);
-
 		MenuInfo menuInfo = getMenuInfo(updateMenuDto.getId());
 		if (canDeleteSavedFile(updateMenuDto, menuInfo.getFile())) {
 			deleteFile(menuInfo.getFile());
 		}
+
+		menuDao.updateById(updateMenuDto);
 	}
 
 	@Transactional


### PR DESCRIPTION
메뉴 수정 시 신규 이미지 업로드할 경우 먼저 메뉴 file_id 업데이트 처리로 인해 신규 이미지 파일 데이터가
삭제되는 이슈 처리했습니다.